### PR TITLE
Fix middleware ordering issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ app.set("view engine", "hbs");
 app.use(express.static("public"));
 app.use(express.static("assets"));
 
-app.use("/api", apiRouter);
-
 // handle HTTP POST requests
 app.use(bodyparser.json());
+
+app.use("/api", apiRouter);
 
 app.get("/", function(req, res, next) {
   res.render("home");


### PR DESCRIPTION
Fixes bug where api routes wouldn't parse request bodies, because the `body-parser` middleware was loaded after the api routes.