### PR TITLE
Fix typo in starting state of class 3

### DIFF
--- a/api/class3.js
+++ b/api/class3.js
@@ -13,7 +13,7 @@ router.delete('/reservations/:id/', function(req, res) {
   const id = req.params.id;
   const sql = 'delete from reservations where id = ' + id;
 
-  db.run(sql, [id], (err, rows) => {
+  db.run(sql, (err, rows) => {
     res.status(200).json({
       customers: rows
     });


### PR DESCRIPTION
You can't pass a non-empty array of parameters to db.run if you don't have any placeholders